### PR TITLE
SVN URL schemes

### DIFF
--- a/lib/util.py
+++ b/lib/util.py
@@ -3,7 +3,7 @@ import os
 import re
 from . import settings
 
-URL_TEST = r"https?:\/\/.*"
+URL_TEST = r"(http|https|svn|svn\+ssh)?:\/\/.*"
 
 
 def get_files(paths=None, group=-1, index=-1, base=None):


### PR DESCRIPTION
Allows for more URL schemes, many functions are using `util.is_url` and things tend to break if the SVN repository checked out is not with a 'https://' URL schema.
