### PR TITLE
branch commands fixes

### DIFF
--- a/HypnotoadSVN.sublime-commands
+++ b/HypnotoadSVN.sublime-commands
@@ -16,6 +16,7 @@
     { "caption": "HypnotoadSVN: Update", "command": "hypno_svn_update"},
     { "caption": "HypnotoadSVN: Commit", "command": "hypno_svn_commit"},
     { "caption": "HypnotoadSVN: Merge", "command": "hypno_svn_merge"},
+    { "caption": "HypnotoadSVN: Merge reintegrate", "command": "hypno_svn_merge_reintegrate"},
     { "caption": "HypnotoadSVN: Diff", "command": "hypno_svn_diff"},
     { "caption": "HypnotoadSVN: Diff with previous version", "command": "hypno_svn_diff_previous"},
     { "caption": "HypnotoadSVN: Check for Modifications", "command": "hypno_svn_status"},

--- a/branch_commands.py
+++ b/branch_commands.py
@@ -175,6 +175,20 @@ class HypnoSvnMergeReintegrateCommand(HypnoSvnMergeCommand):
             sublime.error_message('These revisions argument are not in a valid format:\n ' + '\n '.join(argserr))
             return
         self.run_command('merge --reintegrate ' + ' '.join(params), [self.branch, self.files[0]])
+    
+    def run(self, paths=None, group=-1, index=-1):
+        """Runs the command"""
+        util.debug(self.svn_name)
+        files = util.get_files(paths, group, index)
+        if not util.use_native():
+            sublime.status_message('Merge reintegrate is a native SVN only feature.')
+            return
+        if not self.verify_changes(files):
+            sublime.status_message('Merge cancelled by user.')
+            return
+        self.files = files
+        self.url = self.get_url(files[0])
+        pick_branch(self.url, self.on_branch_picked)
 
 
 class HypnoSvnSwitchCommand(svn_commands.HypnoSvnCommand):

--- a/menus/Default Side Bar.sublime-menu
+++ b/menus/Default Side Bar.sublime-menu
@@ -32,8 +32,6 @@
             { "caption": "Lock", "command": "hypno_svn_lock", "args": {"paths":[]}},
             { "caption": "Steal Lock", "command": "hypno_svn_steal_lock", "args": {"paths":[]}},
             { "caption": "Unlock", "command": "hypno_svn_unlock", "args": {"paths":[]}}
-
-
         ]
     },
     { "caption": "-", "id": "end" }

--- a/menus/Default Side Bar.sublime-menu
+++ b/menus/Default Side Bar.sublime-menu
@@ -3,6 +3,7 @@
     { "caption": "SVN Update", "command": "hypno_svn_update", "args": {"paths":[]}},
     { "caption": "SVN Commit", "command": "hypno_svn_commit", "args": {"paths":[]}},
     { "caption": "SVN Merge", "command": "hypno_svn_merge", "args": {"paths":[]}},
+    { "caption": "SVN Merge reintegrate", "command": "hypno_svn_merge_reintegrate", "args": {"paths":[]}},
     { "caption": "SVN Diff", "command": "hypno_svn_diff", "args": {"paths":[]}},
     { "caption": "SVN Diff with previous version", "command": "hypno_svn_diff_previous", "args": {"paths":[]}},
     {
@@ -31,6 +32,8 @@
             { "caption": "Lock", "command": "hypno_svn_lock", "args": {"paths":[]}},
             { "caption": "Steal Lock", "command": "hypno_svn_steal_lock", "args": {"paths":[]}},
             { "caption": "Unlock", "command": "hypno_svn_unlock", "args": {"paths":[]}}
+
+
         ]
     },
     { "caption": "-", "id": "end" }


### PR DESCRIPTION
- handle merge revisions argument separately, more simple regex
- added a SVN Merge reintegrate to the menu and commands
- fix the 'SVN > Branch', svn copy needs a commit message

I don't know if it is possible or not for you to reintegrate all these changes, but I found myself wondering why the merge command was not working for me so I have tried to fix it and enhance it by handling revisions arguments separately.
Also, I've occurred to need the 'svn --reintegrate' command, so I've used inheritance and created a new entry to the menu with a new command 'SVN Merge reintegrate', which is supposed to work nice when reintegrating a SVN branch to its origin (trunk or other origin branch name).
And there was a problem with the Branch command because even if most svn commands can be executed in non-interactive mode, the 'svn copy' command needs a commit message to create a branch.

If this is too much in one pull, I can also break this in many branch so that you can reintegrate these sequentially. I just though it would be better in one pull because the main impacted file is `branch_commands.py`.
