### PR TITLE
plugin menu removal

### DIFF
--- a/HypnotoadSVN.py
+++ b/HypnotoadSVN.py
@@ -1,4 +1,7 @@
 from .lib import menu
+from package_control import events
+
+HYPNOTOADSVN_PKGNAME = "HypnotoadSVN"
 
 
 def plugin_loaded():
@@ -8,4 +11,5 @@ def plugin_loaded():
 
 def plugin_unloaded():
     """Handles the plugin unloaded event"""
-    menu.remove_user_side_bar()
+    if events.remove(HYPNOTOADSVN_PKGNAME) is not False:
+        menu.remove_user_side_bar()

--- a/HypnotoadSVN.py
+++ b/HypnotoadSVN.py
@@ -4,3 +4,8 @@ from .lib import menu
 def plugin_loaded():
     """Handles the plugin loaded event"""
     menu.create_user_side_bar()
+
+
+def plugin_unloaded():
+    """Handles the plugin unloaded event"""
+    menu.remove_user_side_bar()

--- a/lib/menu.py
+++ b/lib/menu.py
@@ -16,3 +16,10 @@ def create_user_side_bar():
 
     with open(sublime.packages_path() + USER_SIDE_BAR_FILE, 'w', encoding='utf8') as f:
         f.write(side_bar_contents)
+
+
+def remove_user_side_bar():
+    """Remove the sidebar config in the user directory"""
+    if os.path.exists(os.path.join(sublime.packages_path(), 'User', 'HypnotoadSVN')):
+        os.remove(sublime.packages_path() + USER_SIDE_BAR_FILE)
+        os.rmdir(os.path.join(sublime.packages_path(), 'User', 'HypnotoadSVN'))


### PR DESCRIPTION
I think we must clean Sublime Text from installed references by the package, and the side bar menu was not uninstalled when removing the package. Not sure that's the correct way to do that, I just know it's working on my computer.
