### PR TITLE
switch --ignore-ancestry command

### DIFF
--- a/HypnotoadSVN.sublime-commands
+++ b/HypnotoadSVN.sublime-commands
@@ -33,6 +33,7 @@
     { "caption": "HypnotoadSVN: Edit Conflicts", "command": "hypno_svn_conflict_editor"},
     { "caption": "HypnotoadSVN: Resolve", "command": "hypno_svn_resolve"},
     { "caption": "HypnotoadSVN: Switch", "command": "hypno_svn_switch"},
+    { "caption": "HypnotoadSVN: Switch ignore ancestry", "command": "hypno_svn_switch_ignore_ancestry"},
     { "caption": "HypnotoadSVN: Branch", "command": "hypno_svn_branch"},
     { "caption": "HypnotoadSVN: Lock", "command": "hypno_svn_lock"},
     { "caption": "HypnotoadSVN: Steal Lock", "command": "hypno_svn_steal_lock"},

--- a/branch_commands.py
+++ b/branch_commands.py
@@ -220,6 +220,36 @@ class HypnoSvnSwitchCommand(svn_commands.HypnoSvnCommand):
         pick_branch(self.url, self.on_branch_picked)
 
 
+class HypnoSvnSwitchIgnoreAncestryCommand(svn_commands.HypnoSvnCommand):
+    """Switches the working copy to a different branch"""
+
+    def __init__(self, window):
+        """Initialize the command object"""
+        super().__init__(window)
+        self.svn_name = 'Switch ignore ancestry'
+        self.tests = {
+            'versionned': True,
+            'native': True,
+            'single': True
+        }
+        self.native_only = 'switch'
+        self.files = None
+        self.url = None
+
+    def on_branch_picked(self, value):
+        """Handles selecting a value"""
+        self.run_command('switch --ignore-ancestry ', [value, self.files[0]])
+
+
+    def run(self, paths=None, group=-1, index=-1):
+        """Runs the command"""
+        util.debug(self.svn_name)
+        files = util.get_files(paths, group, index)
+        self.files = files
+        self.url = self.get_url(files[0])
+        pick_branch(self.url, self.on_branch_picked)
+
+
 class HypnoSvnBranchCommand(svn_commands.HypnoSvnCommand):
     """Creates a new branch"""
 

--- a/menus/Default Side Bar.sublime-menu
+++ b/menus/Default Side Bar.sublime-menu
@@ -27,6 +27,7 @@
             { "caption": "Resolve", "command": "hypno_svn_resolve", "args": {"paths":[]}},
             { "caption": "-" },
             { "caption": "Switch", "command": "hypno_svn_switch", "args": {"paths":[]}},
+            { "caption": "Switch ignore ancestry", "command": "hypno_svn_switch_ignore_ancestry", "args": {"paths":[]}},
             { "caption": "Branch", "command": "hypno_svn_branch", "args": {"paths":[]}},
             { "caption": "-" },
             { "caption": "Lock", "command": "hypno_svn_lock", "args": {"paths":[]}},


### PR DESCRIPTION
When using SVN, I'm usually in a position of svn repo manager, and not only a developper who is only checking out and committing. So I have written this command so that one can switch inside a SVN repo hierarchy to apply 'administrative' tasks.
I've tried to code this command as a native_only, because I don't know how TortoiseSVN is handling this.
Do you think it is merge-able ?
