### PR TITLE
Do not include svn:externals in 'svn status' check before a commit

### DIFF
--- a/svn_commands.py
+++ b/svn_commands.py
@@ -8,7 +8,7 @@ import time
 from .lib import util, thread, settings, output, panels
 
 LOG_PARSE = r'-{72}[\r\n]+r(\d+) \| ([^|]+) \| ([^|]+) \| [^\n\r]+[\n\r]+(.+)'
-STATUS_PARSE = r'(^[A-Z\?\!\ >]+?) +(\+ +)?(.*)'
+STATUS_PARSE = r'(^[A-W\?\!\ >]+?) +(\+ +)?(.*)'
 INFO_PARSE_REVISION = r'Revision: (\d+)'
 INFO_PARSE_LAST_CHANGE = r'Last Changed Rev: (\d+)'
 INFO_PARSE_URL = r'URL: ([^\n]*)'


### PR DESCRIPTION
It would try to include an external folder to the commit, but it is not relevant since things modified in that folder have to be commited inside that folder. Also, I've checked that 'Y' or 'Z' are not used in `svn status` output.

I know it is possible to make some externals with files only, but I'm not sure it is applicable in the current state of the check. (`svn help status` seems to talk about columns, with peculiar flags for each column, maybe some later investigation could be interesting)
